### PR TITLE
rs: logic for getting worker node with max working capacity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.8)
+project(scheduler_service CXX)
+
+# include gRPC if needed 
+include(/Users/rashmisharma/Development/sjsu/cmpe-275/grpc/examples/cpp/cmake/common.cmake)
+
+# Shared Memory-Based Heap Code
+add_library(heap STATIC heap.cpp)  # assuming heap code is in heap.cpp
+target_include_directories(heap PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>) 
+
+# scheduler Service
+add_executable(scheduler scheduler.cpp)
+
+# link with Heap Library
+target_link_libraries(scheduler heap)
+
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+
+include_directories(${PROTOBUF_INCLUDE_DIR} ${gRPC_CPP_PLUGIN_INCLUDE_DIR} ${gRPC_INCLUDE_DIR})
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS protos/healthcheck.proto)
+grpc_generate_cpp(GRPC_SRCS GRPC_HDRS protos/healthcheck.proto)
+
+add_executable(scheduler scheduler.cpp ${PROTO_SRCS} ${PROTO_HDRS} ${GRPC_SRCS} ${GRPC_HDRS})
+target_link_libraries(scheduler heap ${PROTOBUF_LIBRARY} ${gRPC_LIBRARY})

--- a/Scheduler.cpp
+++ b/Scheduler.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <unistd.h>
+
+#include "heap.h"  // assuming heap.h is available for import
+
+extern key_t worker_heap;  // external key
+
+class Scheduler {
+private:
+    int shm_id;
+    Heap* heap;
+
+public:
+    Scheduler() {
+        shm_id = shmget(worker_heap, sizeof(Heap) + INITIAL_CAPACITY * sizeof(HeapItem), 0666);
+
+        if (shm_id == -1) {
+            perror("shmget failed in Scheduler constructor");
+            exit(1); 
+        }
+
+        heap = (Heap*)shmat(shm_id, NULL, 0);
+        if (heap == (void*) -1) {
+            perror("shmat failed in Scheduler constructor");
+            exit(1);
+        }
+    }
+
+    ~Scheduler() {
+        if (shmdt(heap) == -1) {
+            perror("shmdt failed in Scheduler destructor");
+        }
+    }
+   
+    HeapItem getWorkerWithMaxCapacity() {
+        if (heap->size == 0) {
+            std::cerr << "Error: Heap is empty in Scheduler::getWorkerWithMaxCapacity\n";
+            return HeapItem{.id = "", .value = 0}; 
+        }
+
+        HeapItem maxItem = heap_pop(heap);
+        return maxItem;
+    }
+    
+};

--- a/Scheduler.h
+++ b/Scheduler.h
@@ -1,0 +1,21 @@
+#ifndef SCHEDULER_H
+#define SCHEDULER_H
+
+#include "heap.h"
+// add any needed grpc headers here
+
+class Scheduler {
+public:
+    Scheduler();
+    ~Scheduler();
+
+    // insert any grpc declarations here 
+    
+private:
+    int shm_id;
+    Heap* heap;
+
+    HeapItem getWorkerWithMaxCapacity();
+};
+
+#endif 


### PR DESCRIPTION
base scheduler algo file added, can be added to include other logic 
currently includes logic for getting worker node with max working capacity.
CMakeLists added just in case, can be removed.